### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/out/artifacts/XSS_Scanner/META-INF/maven/commons-collections/commons-collections/pom.xml
+++ b/out/artifacts/XSS_Scanner/META-INF/maven/commons-collections/commons-collections/pom.xml
@@ -27,7 +27,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>commons-collections</groupId>
   <artifactId>commons-collections</artifactId>
-  <version>3.2.1</version>
+  <version>3.2.2</version>
   <name>Commons Collections</name>
 
   <inceptionYear>2001</inceptionYear>

--- a/out/artifacts/XSS_Scanner/META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.xml
+++ b/out/artifacts/XSS_Scanner/META-INF/maven/net.sourceforge.htmlunit/htmlunit/pom.xml
@@ -746,7 +746,7 @@
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
